### PR TITLE
feat: Implemented opus export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +200,8 @@ version = "0.1.0-alpha"
 dependencies = [
  "chrono",
  "rusqlite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -232,6 +240,43 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.22"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
+serde_json = "1.0"
+serde = { version = "1.0.145", features = ["derive"] }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,3 +40,14 @@ opus l 1
 # this clears the whole database
 opus clear
 ```
+
+## Export Tasks
+- opus exports all tasks to a specified file
+```bash
+# Exports all tasks in a data.json file
+opus export json data
+# mycsvfile.csv
+opus export csv mycsvfile
+# data.tsv
+opus export tsv data
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,10 @@ pub fn parse_args(args: Vec<String>) -> Cli {
         "ls" | "l" => ArgumentType::List,
         "clear" => ArgumentType::Clear,
         "export" => {
+            if args.len() <= 3 {
+                panic!("Not enough args for export")
+            }
+            
             let file_name = args[3].to_lowercase();
             match args[2].to_lowercase().as_str() {
                 "json" => ArgumentType::Export {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::types::{ArgumentType, Cli, CliInput, Task};
+use crate::types::{ArgumentType, Cli, CliInput, Task, ExportType};
 use chrono::Utc;
 
 /// Converts command line arguments into machine readable format
@@ -56,12 +56,22 @@ pub fn parse_args(args: Vec<String>) -> Cli {
         "del" | "d" => ArgumentType::Delete,
         "ls" | "l" => ArgumentType::List,
         "clear" => ArgumentType::Clear,
+        "export" => {
+            let file_name = args[3].to_lowercase();
+            match args[2].to_lowercase().as_str() {
+                "json" => ArgumentType::Export{export_type: ExportType::Json, file_name },
+                "csv" => ArgumentType::Export{export_type: ExportType::Csv, file_name },
+                "tsv" => ArgumentType::Export{export_type: ExportType::Tsv, file_name },
+                _ => panic!("Unknown format \"{}\"", args[2].to_lowercase())
+            }
+        },
         _ => ArgumentType::Unknown,
     };
 
-    r.top_level_arg = if args.len() <= 2
+    r.top_level_arg = if (args.len() <= 2
         && r.top_level_arg != ArgumentType::List
-        && r.top_level_arg != ArgumentType::Clear
+        && r.top_level_arg != ArgumentType::Clear) ||
+        (args.len() <= 3 && matches!(r.top_level_arg, ArgumentType::Export { export_type: _ , file_name: _ }))
     {
         ArgumentType::Notenough
     } else {
@@ -70,9 +80,10 @@ pub fn parse_args(args: Vec<String>) -> Cli {
 
     let mut task: Vec<&str> = vec![];
 
-    match r.top_level_arg {
+    match &r.top_level_arg {
         ArgumentType::List => (),
         ArgumentType::Clear => (),
+        ArgumentType::Export { export_type: _, file_name: file } => (),
         ArgumentType::Unknown => panic!(
             "Unknown Argument '{}', run 'opus help' for more info on command syntax.",
             args[1]
@@ -160,4 +171,8 @@ pub fn cli_get_tasks(db: &Database, q: String) -> Vec<Task> {
 /// clear the whole database
 pub fn cli_clear(db: &Database) -> bool {
     db.clear_all_tasks() != 0
+}
+
+pub fn cli_export(db: &Database, export_type: &ExportType) -> String {
+    db.export(export_type)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::types::{ArgumentType, Cli, CliInput, Task, ExportType};
+use crate::types::{ArgumentType, Cli, CliInput, ExportType, Task};
 use chrono::Utc;
 
 /// Converts command line arguments into machine readable format
@@ -59,20 +59,35 @@ pub fn parse_args(args: Vec<String>) -> Cli {
         "export" => {
             let file_name = args[3].to_lowercase();
             match args[2].to_lowercase().as_str() {
-                "json" => ArgumentType::Export{export_type: ExportType::Json, file_name },
-                "csv" => ArgumentType::Export{export_type: ExportType::Csv, file_name },
-                "tsv" => ArgumentType::Export{export_type: ExportType::Tsv, file_name },
-                _ => panic!("Unknown format \"{}\"", args[2].to_lowercase())
+                "json" => ArgumentType::Export {
+                    export_type: ExportType::Json,
+                    file_name,
+                },
+                "csv" => ArgumentType::Export {
+                    export_type: ExportType::Csv,
+                    file_name,
+                },
+                "tsv" => ArgumentType::Export {
+                    export_type: ExportType::Tsv,
+                    file_name,
+                },
+                _ => panic!("Unknown format \"{}\"", args[2].to_lowercase()),
             }
-        },
+        }
         _ => ArgumentType::Unknown,
     };
 
     r.top_level_arg = if (args.len() <= 2
         && r.top_level_arg != ArgumentType::List
-        && r.top_level_arg != ArgumentType::Clear) ||
-        (args.len() <= 3 && matches!(r.top_level_arg, ArgumentType::Export { export_type: _ , file_name: _ }))
-    {
+        && r.top_level_arg != ArgumentType::Clear)
+        || (args.len() <= 3
+            && matches!(
+                r.top_level_arg,
+                ArgumentType::Export {
+                    export_type: _,
+                    file_name: _
+                }
+            )) {
         ArgumentType::Notenough
     } else {
         r.top_level_arg
@@ -83,7 +98,10 @@ pub fn parse_args(args: Vec<String>) -> Cli {
     match &r.top_level_arg {
         ArgumentType::List => (),
         ArgumentType::Clear => (),
-        ArgumentType::Export { export_type: _, file_name: file } => (),
+        ArgumentType::Export {
+            export_type: _,
+            file_name: file,
+        } => (),
         ArgumentType::Unknown => panic!(
             "Unknown Argument '{}', run 'opus help' for more info on command syntax.",
             args[1]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ pub fn parse_args(args: Vec<String>) -> Cli {
             if args.len() <= 3 {
                 panic!("Not enough args for export")
             }
-            
+
             let file_name = args[3].to_lowercase();
             match args[2].to_lowercase().as_str() {
                 "json" => ArgumentType::Export {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,11 @@
 //! # Opus database wrapper
 use rusqlite::Connection;
 
-use crate::{types::{Task, ExportType}, util::create_dir_if_not_exist, util::get_db_path};
+use crate::{
+    types::{ExportType, Task},
+    util::create_dir_if_not_exist,
+    util::get_db_path,
+};
 
 pub struct Database {
     pub con: Connection,
@@ -138,16 +142,24 @@ impl Database {
         let tasks = self.get_tasks('l', "l".to_string());
 
         let tasks = match export_type {
-            ExportType::Json => serde_json::to_string(&tasks).map_err(|_| "Exporting failed".to_owned()),
+            ExportType::Json => {
+                serde_json::to_string(&tasks).map_err(|_| "Exporting failed".to_owned())
+            }
             _ => {
-                let sep = match export_type{
+                let sep = match export_type {
                     ExportType::Csv => ",",
                     _ => "\t",
                 };
 
-                Ok(tasks.iter()
-                .map(|t| format!("{}{sep}{}{sep}{}{sep}{}{sep}{}\n", t.title, t.tag, t.priority, t.due, t.finished))
-                .collect::<String>())
+                Ok(tasks
+                    .iter()
+                    .map(|t| {
+                        format!(
+                            "{}{sep}{}{sep}{}{sep}{}{sep}{}\n",
+                            t.title, t.tag, t.priority, t.due, t.finished
+                        )
+                    })
+                    .collect::<String>())
             }
         };
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 //! # Opus database wrapper
 use rusqlite::Connection;
 
-use crate::{types::Task, util::create_dir_if_not_exist, util::get_db_path};
+use crate::{types::{Task, ExportType}, util::create_dir_if_not_exist, util::get_db_path};
 
 pub struct Database {
     pub con: Connection,
@@ -132,5 +132,25 @@ impl Database {
         self.con
             .execute(REMOVE_ALL_TASKS, [])
             .expect("Clearing database failed")
+    }
+
+    pub fn export(&self, export_type: &ExportType) -> String {
+        let tasks = self.get_tasks('l', "l".to_string());
+
+        let tasks = match export_type {
+            ExportType::Json => serde_json::to_string(&tasks).map_err(|_| "Exporting failed".to_owned()),
+            _ => {
+                let sep = match export_type{
+                    ExportType::Csv => ",",
+                    _ => "\t",
+                };
+
+                Ok(tasks.iter()
+                .map(|t| format!("{}{sep}{}{sep}{}{sep}{}{sep}{}\n", t.title, t.tag, t.priority, t.due, t.finished))
+                .collect::<String>())
+            }
+        };
+
+        tasks.expect("Exporting failed")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@
 //! opus ls ","       # List all tasks with priority !! (2):
 //! opus ls .2        # List task with id 2
 //! ```
-//! 
+//!
 //! ### Export tasks
-//! 
+//!
 //! ```bash
 //! opus export json data       # Exports all tasks in a data.json file
 //! opus export csv mycsvfile   # mycsvfile.csv
@@ -83,7 +83,11 @@ fn main() {
             let tasks = cli_get_tasks(&db, query.clone());
             println!("{:#?}", &tasks);
             println!("--");
-            println!("TODO: {} tasks found matching query: '{}'", tasks.len(), query);
+            println!(
+                "TODO: {} tasks found matching query: '{}'",
+                tasks.len(),
+                query
+            );
         }
         ArgumentType::Finish => {
             if cli_fin_task(&db, result.input.query.unwrap()) {
@@ -93,20 +97,23 @@ fn main() {
             }
         }
         ArgumentType::Clear => {
-            if cli_clear(&db){
+            if cli_clear(&db) {
                 println!("removed all tasks from database");
             } else {
                 println!("couldn't remove all tasks from the database");
             }
         }
-        // ArgumentType::Export(export_type) => todo!(),
-        ArgumentType::Export { export_type, file_name } => {
+        ArgumentType::Export {
+            export_type,
+            file_name,
+        } => {
             let data = cli_export(&db, export_type);
 
             let file_name_with_extension = format!("{}.{}", file_name, export_type);
-            let mut file = std::fs::File::create(file_name_with_extension).expect("Unable to open file");
+            let mut file =
+                std::fs::File::create(file_name_with_extension).expect("Unable to open file");
             write!(file, "{}", data).expect("Unable to write");
-        },
+        }
         _ => panic!("Unknown argument."),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,18 @@
 //! opus ls ","       # List all tasks with priority !! (2):
 //! opus ls .2        # List task with id 2
 //! ```
+//! 
+//! ### Export tasks
+//! 
+//! ```bash
+//! opus export json data       # Exports all tasks in a data.json file
+//! opus export csv mycsvfile   # mycsvfile.csv
+//! opus export tsv data        # data.tsv
+//! ```
 //!
 //! ## Contributing
 use std::env;
+use std::io::Write;
 
 use cli::*;
 use db::{open_db, Database};
@@ -90,6 +99,14 @@ fn main() {
                 println!("couldn't remove all tasks from the database");
             }
         }
+        // ArgumentType::Export(export_type) => todo!(),
+        ArgumentType::Export { export_type, file_name } => {
+            let data = cli_export(&db, export_type);
+
+            let file_name_with_extension = format!("{}.{}", file_name, export_type);
+            let mut file = std::fs::File::create(file_name_with_extension).expect("Unable to open file");
+            write!(file, "{}", data).expect("Unable to write");
+        },
         _ => panic!("Unknown argument."),
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,13 +30,13 @@ mod cli {
             ArgumentType::Finish,
             ArgumentType::List,
         ];
-        for i in 0..4 {
+        for (arg, arg_type) in args.iter().zip(args_types) {
             let r = parse_args(vec![
                 "opus".to_string(),
-                args[i].to_string(),
+                arg.to_string(),
                 "arg2".to_string(),
             ]);
-            assert_eq!(r.top_level_arg, args_types[i]);
+            assert_eq!(r.top_level_arg, arg_type);
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,21 +44,44 @@ mod cli {
 
     #[test]
     fn parse_export() {
-
         let inputs = [
-            vec!["opus".to_owned(), "export".to_owned(), "csv".to_owned(), "tmp1".to_owned()],
-            vec!["opus".to_owned(), "export".to_owned(), "tsv".to_owned(), "tmp2".to_owned()],
-            vec!["opus".to_owned(), "export".to_owned(), "json".to_owned(), "tmp3".to_owned()]
+            vec![
+                "opus".to_owned(),
+                "export".to_owned(),
+                "csv".to_owned(),
+                "tmp1".to_owned(),
+            ],
+            vec![
+                "opus".to_owned(),
+                "export".to_owned(),
+                "tsv".to_owned(),
+                "tmp2".to_owned(),
+            ],
+            vec![
+                "opus".to_owned(),
+                "export".to_owned(),
+                "json".to_owned(),
+                "tmp3".to_owned(),
+            ],
         ];
 
         let expected = [
-            ArgumentType::Export { export_type: crate::types::ExportType::Csv, file_name: "tmp1".to_owned() },
-            ArgumentType::Export { export_type: crate::types::ExportType::Tsv, file_name: "tmp2".to_owned() },
-            ArgumentType::Export { export_type: crate::types::ExportType::Json, file_name: "tmp3".to_owned() },
+            ArgumentType::Export {
+                export_type: crate::types::ExportType::Csv,
+                file_name: "tmp1".to_owned(),
+            },
+            ArgumentType::Export {
+                export_type: crate::types::ExportType::Tsv,
+                file_name: "tmp2".to_owned(),
+            },
+            ArgumentType::Export {
+                export_type: crate::types::ExportType::Json,
+                file_name: "tmp3".to_owned(),
+            },
         ];
 
         for (input, expected) in inputs.iter().zip(expected) {
-            assert_eq!(parse_args(input.to_owned()).top_level_arg, expected)   
+            assert_eq!(parse_args(input.to_owned()).top_level_arg, expected)
         }
     }
 
@@ -72,7 +95,7 @@ mod cli {
     fn not_enough_arguments_ii() {
         parse_args(vec!["opus".to_string(), "add".to_string()]);
     }
-    
+
     #[test]
     #[should_panic]
     fn not_enough_arguments_export_1() {
@@ -82,13 +105,21 @@ mod cli {
     #[test]
     #[should_panic]
     fn not_enough_arguments_export_2() {
-        parse_args(vec!["opus".to_string(), "export".to_string(), "csv".to_owned()]);
+        parse_args(vec![
+            "opus".to_string(),
+            "export".to_string(),
+            "csv".to_owned(),
+        ]);
     }
-    
+
     #[test]
     #[should_panic]
     fn not_enough_arguments_export_3() {
-        parse_args(vec!["opus".to_string(), "export".to_string(), "file".to_owned()]);
+        parse_args(vec![
+            "opus".to_string(),
+            "export".to_string(),
+            "file".to_owned(),
+        ]);
     }
 
     #[test]
@@ -215,7 +246,14 @@ mod cli {
         let output = db.export(&crate::types::ExportType::Csv);
         assert_eq!(output, "");
 
-        db.insert_task(Task{ id: Some(1_usize), title: "title".to_owned(), tag: "tag".to_owned(), priority: 2_usize, due: "due".to_owned(), finished: false });
+        db.insert_task(Task {
+            id: Some(1_usize),
+            title: "title".to_owned(),
+            tag: "tag".to_owned(),
+            priority: 2_usize,
+            due: "due".to_owned(),
+            finished: false,
+        });
 
         let output = db.export(&crate::types::ExportType::Csv);
         assert_eq!(output, "title,tag,2,due,false\n");

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 //! Opus types
+use serde::Serialize;
+use std::fmt;
 /// User action
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgumentType {
     /// add a new todo
     Add,
@@ -16,6 +18,24 @@ pub enum ArgumentType {
     Unknown,
     /// not enough arguments supplied
     Notenough,
+    Export { export_type: ExportType, file_name: String }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportType {
+    Json,
+    Csv,
+    Tsv,
+}
+
+impl fmt::Display for ExportType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExportType::Json => write!(f, "json"),
+            ExportType::Csv => write!(f, "csv"),
+            ExportType::Tsv => write!(f, "tsv"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -24,7 +44,7 @@ pub struct CliInput {
     pub query: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Task {
     pub id: Option<usize>,
     pub title: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use std::fmt;
 pub enum ArgumentType {
     /// add a new todo
     Add,
-    /// delete a todo 
+    /// delete a todo
     Delete,
     /// remove all tasks
     Clear,
@@ -18,7 +18,10 @@ pub enum ArgumentType {
     Unknown,
     /// not enough arguments supplied
     Notenough,
-    Export { export_type: ExportType, file_name: String }
+    Export {
+        export_type: ExportType,
+        file_name: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Closes #6.

I tried to keep my code similar to yours when it comes to what types are returned where but let me know if you want something changed.

## Usage

```rust
//! ### Export tasks
//! 
//! ```bash
//! opus export json data       # Exports all tasks in a data.json file
//! opus export csv mycsvfile   # mycsvfile.csv
//! opus export tsv data        # data.tsv
//! ```
```

Comment is from [`main.rs`](https://github.com/AntoniosBarotsis/opusCli/blob/9743188833cbb3dbee18984857ee536fedf94880/src/main.rs#L40-L46).

Added TSV since plain text might include commas which would break CSV. Both CSV and TSV are implemented by hand while JSON uses Serde.

If everything looks fine to you, consider adding a `hacktoberfest-accepted` label to the PR :)