### PR TITLE
test: use sqlite in-memory db when running tests

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -23,9 +23,15 @@ pub const INSERT_TASK: &str =
     "INSERT INTO tasks (title, tag, due, priority, finished) VALUES(?,?,?,?,?)";
 
 pub fn open_db() -> Database {
-    let path = get_db_path();
-    create_dir_if_not_exist(&path);
-    match Connection::open(path) {
+    let con = if cfg!(test) {
+        Connection::open_in_memory()
+    } else {
+        let path = get_db_path();
+        create_dir_if_not_exist(&path);
+        Connection::open(path)
+    };
+
+    match con {
         Ok(con) => Database { con },
         Err(_) => panic!("Couldn't open database!"),
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -242,7 +242,6 @@ mod cli {
         let db = open_db();
 
         db.create_table_if_missing();
-        db.clear_all_tasks();
 
         let tasks = db.get_tasks('l', "l".to_string()).len();
         assert_eq!(tasks, 0);
@@ -273,7 +272,6 @@ mod cli {
         let db = open_db();
 
         db.create_table_if_missing();
-        db.clear_all_tasks();
         let output = db.export(&crate::types::ExportType::Csv);
         assert_eq!(output, "");
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -242,6 +242,8 @@ mod cli {
         let db = open_db();
 
         db.create_table_if_missing();
+        db.insert_task(task);
+        db.clear_all_tasks();
 
         let tasks = db.get_tasks('l', "l".to_string()).len();
         assert_eq!(tasks, 0);
@@ -303,9 +305,9 @@ mod util {
     #[test]
     fn create_dir_if_no_exist() {
         let path = get_db_path();
-        create_dir_if_not_exist(&path);
+        assert!(create_dir_if_not_exist(&path));
         let ppath = Path::new(&path);
-        assert!(ppath.exists());
+        assert!(ppath.parent().expect("Couldn't get directory of db file").exists());
     }
 }
 


### PR DESCRIPTION
Changes `db` to use a temporary in-memory database for unit testing. That way the actual database file doesn't get modified and cleared after each test run.