### PR TITLE
test: add missing asserts to task.compare_content() calls

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -94,7 +94,7 @@ mod cli {
         use crate::cli::cli_add_task;
         use crate::{db::open_db, types::Task};
 
-        let task = Task::from("update excel sheet #work @today .5");
+        let mut task = Task::from("update excel sheet #work @today .5");
         let db = open_db();
 
         db.create_table_if_missing();
@@ -107,6 +107,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, id.to_string(), true);
         let task1 = tasks.get(0).unwrap();
 
+        task.finished = true;
         assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, last_id.to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -65,7 +65,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, "#test".to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -84,7 +84,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, ".18".to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -107,7 +107,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, id.to_string(), true);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }


### PR DESCRIPTION
While refactoring the test task compare code into `Task::content_compare` in https://github.com/xNaCly/opusCli/pull/17#discussion_r997366927 the asserts went missing (oh no). Adds them back so that if the comparsion return false the tests will fail.