### PR TITLE
Feat/list sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opus"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha+experimental.ls-sorting"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opus"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha+experimental.ls-sorting"
 authors = ["xnacly <47723417+xNaCly@users.noreply.github.com>"]
 description = "Manage tasks with ease"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ opus list 1
 opus ls 1
 opus l 1
 # sort list output by task property
-opus list --sort_by=id
-opus list --sort_by=due
-opus list --sort_by=finished
-opus list --sort_by=title
-opus list --sort_by=priority
-opus list --sort_by=tag
+opus list --sort-by=id
+opus list --sort-by=due
+opus list --sort-by=finished
+opus list --sort-by=title
+opus list --sort-by=priority
+opus list --sort-by=tag
 # sort desc and asc (default sort is asc)
-opus list --sort_by=id --sort_mode=desc
+opus list --sort-by=id --sort-order=desc
 # [2]: 'read c how to' (2022-10-17)
 # [1]: 'notion aufsetzen' (2022-10-18) #uni .1
 # --

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ opus list .3
 opus list 1
 opus ls 1
 opus l 1
+# sort list output by task property
+opus list --sort_by=id
+opus list --sort_by=due
+opus list --sort_by=finished
+opus list --sort_by=title
+opus list --sort_by=priority
+opus list --sort_by=tag
+# sort desc and asc (default sort is asc)
+opus list --sort_by=id --sort_mode=desc
+# [2]: 'read c how to' (2022-10-17)
+# [1]: 'notion aufsetzen' (2022-10-18) #uni .1
+# --
+# 2 tasks found matching query: 'list'
 ```
 
 ### Mark a task as finished

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::types::{ExportType, Task};
+use crate::types::{ExportType, SortDirection, SortMode, Task};
 
 /// add the given Task to the database
 pub fn cli_add_task(db: &Database, t: Task) {
@@ -30,11 +30,19 @@ pub fn cli_fin_task(db: &Database, id: String) -> bool {
     db.mark_task_as_finished(id.parse::<usize>().expect("Given id wasn't an integer")) != 0
 }
 
-pub fn cli_get_tasks(db: &Database, q: String, display_finished: bool) -> Vec<Task> {
+pub fn cli_get_tasks(
+    db: &Database,
+    q: String,
+    display_finished: bool,
+    sort_by: SortMode,
+    sort_direction: SortDirection,
+) -> Vec<Task> {
     db.get_tasks(
         q.chars().next().expect("Failure in getting task query"),
         q,
         display_finished,
+        sort_by,
+        sort_direction,
     )
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::db::Database;
-use crate::types::{ExportType, SortDirection, SortMode, Task};
+use crate::types::{ExportType, SortMode, SortOrder, Task};
 
 /// add the given Task to the database
 pub fn cli_add_task(db: &Database, t: Task) {
@@ -35,14 +35,14 @@ pub fn cli_get_tasks(
     q: String,
     display_finished: bool,
     sort_by: SortMode,
-    sort_direction: SortDirection,
+    sort_order: SortOrder,
 ) -> Vec<Task> {
     db.get_tasks(
         q.chars().next().expect("Failure in getting task query"),
         q,
         display_finished,
         sort_by,
-        sort_direction,
+        sort_order,
     )
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@
 use rusqlite::{Connection, Row};
 
 use crate::{
-    types::{ExportType, SortDirection, SortMode, Task},
+    types::{ExportType, SortMode, SortOrder, Task},
     util::create_dir_if_not_exist,
     util::get_db_path,
 };
@@ -55,7 +55,7 @@ impl Database {
         mut query: String,
         display_finished: bool,
         sort_by: SortMode,
-        sort_direction: SortDirection,
+        sort_order: SortOrder,
     ) -> Vec<Task> {
         let mut sql_query = match property {
             '#' => GET_TASK_BY_TAG,
@@ -64,15 +64,22 @@ impl Database {
                 unimplemented!("querying via date will be implemented in the future");
             }
             _ => GET_TASK_BY_ID,
-        };
+        }
+        .to_string();
 
         if query == "list" || query == "l" {
-            sql_query = GET_ALL_TASKS;
+            sql_query = GET_ALL_TASKS.to_string();
         }
+
+        sql_query = if sort_by != SortMode::NoSort {
+            format!("{} ORDER BY {} {}", sql_query, sort_by, sort_order)
+        } else {
+            sql_query
+        };
 
         let mut stmt = self
             .con
-            .prepare(sql_query)
+            .prepare(sql_query.as_str())
             .expect("Failed to prepare SQL statement in querying for tasks");
 
         if sql_query == GET_TASK_BY_PRIO {
@@ -151,13 +158,7 @@ impl Database {
     }
 
     pub fn export(&self, export_type: &ExportType) -> String {
-        let tasks = self.get_tasks(
-            'l',
-            "l".to_string(),
-            true,
-            SortMode::NoSort,
-            SortDirection::ASC,
-        );
+        let tasks = self.get_tasks('l', "l".to_string(), true, SortMode::NoSort, SortOrder::ASC);
 
         let tasks = match export_type {
             ExportType::Json => {

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@
 use rusqlite::{Connection, Row};
 
 use crate::{
-    types::{ExportType, Task},
+    types::{ExportType, SortDirection, SortMode, Task},
     util::create_dir_if_not_exist,
     util::get_db_path,
 };
@@ -54,6 +54,8 @@ impl Database {
         property: char,
         mut query: String,
         display_finished: bool,
+        sort_by: SortMode,
+        sort_direction: SortDirection,
     ) -> Vec<Task> {
         let mut sql_query = match property {
             '#' => GET_TASK_BY_TAG,
@@ -149,7 +151,13 @@ impl Database {
     }
 
     pub fn export(&self, export_type: &ExportType) -> String {
-        let tasks = self.get_tasks('l', "l".to_string(), true);
+        let tasks = self.get_tasks(
+            'l',
+            "l".to_string(),
+            true,
+            SortMode::NoSort,
+            SortDirection::ASC,
+        );
 
         let tasks = match export_type {
             ExportType::Json => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
                         "sort tasks by given param: (id, due, finished, title, priority, tag)",
                     ))
                     .arg(Arg::new("sort_order").long("sort_order").help(
-                        "sort tasks by given param: (id, due, finished, title, priority, tag)",
+                        "sort direction: (asc, desc)",
                     ))
                     .arg(
                         // INFO: documentation for flags: https://docs.rs/clap/latest/clap/_tutorial/index.html#flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,64 +14,68 @@ mod tests;
 
 fn main() {
     // INFO: documentation clap: https://docs.rs/clap/latest/clap/_tutorial/index.html#subcommands
-    let commands = command!()
-        .about(crate_description!())
-        .author(crate_authors!("\n"))
-        .propagate_version(true)
-        .subcommand_required(true)
-        .arg_required_else_help(true)
-        .subcommand(
-            Command::new("add")
-                .visible_alias("a")
-                .about("create a new task")
-                .arg(arg!(<CONTENT>)),
-        )
-        .subcommand(
-            Command::new("delete")
-                .visible_aliases(["del", "d"])
-                .about("delete a task with the given id")
-                .arg(arg!(<ID>)),
-        )
-        .subcommand(Command::new("clear").about("remove all tasks from the database"))
-        .subcommand(
-            Command::new("finish")
-                .visible_aliases(["fin", "f"])
-                .about("mark the task with the given id as finished")
-                .arg(arg!(<ID>)),
-        )
-        .subcommand(
-            Command::new("list")
-                .visible_aliases(["ls", "l"])
-                .about("list tasks matching the given query")
-                .arg(arg!([QUERY]))
-                .arg(
-                    // INFO: documentation for flags: https://docs.rs/clap/latest/clap/_tutorial/index.html#flags
-                    Arg::new("finished")
-                        .short('f')
-                        .long("finished")
-                        .action(ArgAction::SetTrue)
-                        .help("displays tasks marked as finished"),
-                ),
-        )
-        .subcommand(
-            Command::new("export")
-                .about("export all tasks")
-                .arg(
-                    Arg::new("fileformat")
-                        .long("format")
-                        .short('f')
-                        .required(true)
-                        .help("select the export format: json or csv"),
-                )
-                .arg(
-                    Arg::new("filename")
-                        .long("output")
-                        .short('o')
-                        .required(true)
-                        .help("select the filename for the export"),
-                ),
-        )
-        .get_matches();
+    let commands =
+        command!()
+            .about(crate_description!())
+            .author(crate_authors!("\n"))
+            .propagate_version(true)
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .subcommand(
+                Command::new("add")
+                    .visible_alias("a")
+                    .about("create a new task")
+                    .arg(arg!(<CONTENT>)),
+            )
+            .subcommand(
+                Command::new("delete")
+                    .visible_aliases(["del", "d"])
+                    .about("delete a task with the given id")
+                    .arg(arg!(<ID>)),
+            )
+            .subcommand(Command::new("clear").about("remove all tasks from the database"))
+            .subcommand(
+                Command::new("finish")
+                    .visible_aliases(["fin", "f"])
+                    .about("mark the task with the given id as finished")
+                    .arg(arg!(<ID>)),
+            )
+            .subcommand(
+                Command::new("list")
+                    .visible_aliases(["ls", "l"])
+                    .about("list tasks matching the given query")
+                    .arg(arg!([QUERY]))
+                    .arg(Arg::new("sort_by").short('b').long("sort_by").help(
+                        "sort tasks by given param: (id, due, finished, title, priority, tag)",
+                    ))
+                    .arg(
+                        // INFO: documentation for flags: https://docs.rs/clap/latest/clap/_tutorial/index.html#flags
+                        Arg::new("finished")
+                            .short('f')
+                            .long("finished")
+                            .action(ArgAction::SetTrue)
+                            .help("displays tasks marked as finished"),
+                    ),
+            )
+            .subcommand(
+                Command::new("export")
+                    .about("export all tasks")
+                    .arg(
+                        Arg::new("fileformat")
+                            .long("format")
+                            .short('f')
+                            .required(true)
+                            .help("select the export format: json or csv"),
+                    )
+                    .arg(
+                        Arg::new("filename")
+                            .long("output")
+                            .short('o')
+                            .required(true)
+                            .help("select the filename for the export"),
+                    ),
+            )
+            .get_matches();
 
     let db: Database = open_db();
     db.create_table_if_missing();

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn main() {
                     .visible_aliases(["ls", "l"])
                     .about("list tasks matching the given query")
                     .arg(arg!([QUERY]))
-                    .arg(Arg::new("sort_by").long("sort_by").help(
+                    .arg(Arg::new("sort-by").long("sort-by").help(
                         "sort tasks by given param: (id, due, finished, title, priority, tag)",
                     ))
-                    .arg(Arg::new("sort_order").long("sort_order").help(
+                    .arg(Arg::new("sort-order").long("sort-order").help(
                         "sort direction: (asc, desc)",
                     ))
                     .arg(
@@ -89,11 +89,11 @@ fn main() {
         Some(("list", sub_matches)) => {
             let display_finished = sub_matches.get_flag("finished");
             let default_value = &String::from("list");
-            let sort_by = match sub_matches.get_one::<String>("sort_by") {
+            let sort_by = match sub_matches.get_one::<String>("sort-by") {
                 Some(e) => SortMode::from(&e[..]),
                 _ => SortMode::NoSort,
             };
-            let sort_order = match sub_matches.get_one::<String>("sort_order") {
+            let sort_order = match sub_matches.get_one::<String>("sort-order") {
                 Some(e) => SortOrder::from(&e[..]),
                 _ => SortOrder::ASC,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::io::Write;
 use std::{env, fs::File};
 use types::{ExportType, Task};
 
+use crate::types::{SortMode, SortOrder};
+
 mod cli;
 mod db;
 mod types;
@@ -45,7 +47,10 @@ fn main() {
                     .visible_aliases(["ls", "l"])
                     .about("list tasks matching the given query")
                     .arg(arg!([QUERY]))
-                    .arg(Arg::new("sort_by").short('b').long("sort_by").help(
+                    .arg(Arg::new("sort_by").long("sort_by").help(
+                        "sort tasks by given param: (id, due, finished, title, priority, tag)",
+                    ))
+                    .arg(Arg::new("sort_order").long("sort_order").help(
                         "sort tasks by given param: (id, due, finished, title, priority, tag)",
                     ))
                     .arg(
@@ -84,10 +89,24 @@ fn main() {
         Some(("list", sub_matches)) => {
             let display_finished = sub_matches.get_flag("finished");
             let default_value = &String::from("list");
+            let sort_by = match sub_matches.get_one::<String>("sort_by") {
+                Some(e) => SortMode::from(&e[..]),
+                _ => SortMode::NoSort,
+            };
+            let sort_order = match sub_matches.get_one::<String>("sort_order") {
+                Some(e) => SortOrder::from(&e[..]),
+                _ => SortOrder::ASC,
+            };
             let query = sub_matches
                 .get_one::<String>("QUERY")
                 .unwrap_or(default_value);
-            let tasks = cli_get_tasks(&db, query.to_string(), display_finished);
+            let tasks = cli_get_tasks(
+                &db,
+                query.to_string(),
+                display_finished,
+                sort_by,
+                sort_order,
+            );
             for t in &tasks {
                 println!("{}", t);
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,10 @@ impl Task {
 
 #[cfg(test)]
 mod cli {
-    use crate::cli::{cli_clear, cli_del_task, cli_fin_task, cli_get_tasks};
+    use crate::{
+        cli::{cli_clear, cli_del_task, cli_fin_task, cli_get_tasks},
+        types::{SortMode, SortOrder},
+    };
 
     #[test]
     fn insert_task() {
@@ -43,7 +46,13 @@ mod cli {
 
         let last_id = db.con.last_insert_rowid();
 
-        let tasks = cli_get_tasks(&db, last_id.to_string(), false);
+        let tasks = cli_get_tasks(
+            &db,
+            last_id.to_string(),
+            false,
+            SortMode::NoSort,
+            SortOrder::ASC,
+        );
         let task1 = tasks.get(0).unwrap();
 
         assert!(task.content_compare(task1));
@@ -62,7 +71,14 @@ mod cli {
         db.create_table_if_missing();
         cli_add_task(&db, task.clone());
 
-        let tasks = cli_get_tasks(&db, "#test".to_string(), false);
+        let tasks = cli_get_tasks(
+            &db,
+            "#test".to_string(),
+            false,
+            SortMode::NoSort,
+            SortOrder::ASC,
+        );
+
         let task1 = tasks.get(0).unwrap();
 
         assert!(task.content_compare(task1));
@@ -81,7 +97,13 @@ mod cli {
         db.create_table_if_missing();
         cli_add_task(&db, task.clone());
 
-        let tasks = cli_get_tasks(&db, ".18".to_string(), false);
+        let tasks = cli_get_tasks(
+            &db,
+            ".18".to_string(),
+            false,
+            SortMode::NoSort,
+            SortOrder::ASC,
+        );
         let task1 = tasks.get(0).unwrap();
 
         assert!(task.content_compare(task1));
@@ -104,7 +126,7 @@ mod cli {
 
         cli_fin_task(&db, id.to_string());
 
-        let tasks = cli_get_tasks(&db, id.to_string(), true);
+        let tasks = cli_get_tasks(&db, id.to_string(), true, SortMode::NoSort, SortOrder::ASC);
         let task1 = tasks.get(0).unwrap();
 
         task.finished = true;
@@ -125,7 +147,13 @@ mod cli {
         cli_add_task(&db, task.clone());
         cli_clear(&db);
 
-        let tasks = cli_get_tasks(&db, "list".to_string(), true);
+        let tasks = cli_get_tasks(
+            &db,
+            "list".to_string(),
+            true,
+            SortMode::NoSort,
+            SortOrder::ASC,
+        );
 
         assert_eq!(tasks.len(), 0);
 
@@ -147,7 +175,13 @@ mod cli {
 
         cli_del_task(&db, id.to_string());
 
-        let tasks = cli_get_tasks(&db, "#delete".to_string(), true);
+        let tasks = cli_get_tasks(
+            &db,
+            "#delete".to_string(),
+            true,
+            SortMode::NoSort,
+            SortOrder::ASC,
+        );
 
         assert_eq!(tasks.len(), 0);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, last_id.to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -65,7 +65,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, "#test".to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -84,7 +84,7 @@ mod cli {
         let tasks = cli_get_tasks(&db, ".18".to_string(), false);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }
@@ -94,7 +94,7 @@ mod cli {
         use crate::cli::cli_add_task;
         use crate::{db::open_db, types::Task};
 
-        let task = Task::from("update excel sheet #work @today .5");
+        let mut task = Task::from("update excel sheet #work @today .5");
         let db = open_db();
 
         db.create_table_if_missing();
@@ -107,7 +107,8 @@ mod cli {
         let tasks = cli_get_tasks(&db, id.to_string(), true);
         let task1 = tasks.get(0).unwrap();
 
-        task.content_compare(task1);
+        task.finished = true;
+        assert!(task.content_compare(task1));
 
         db.con.close().expect("Closing Database failed.");
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,7 @@ pub enum ExportType {
     Tsv,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortMode {
     Id,
     Due,
@@ -20,6 +21,24 @@ pub enum SortMode {
     Priority,
     Tag,
     NoSort,
+}
+
+impl fmt::Display for SortMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Id => "id",
+                Self::Due => "due",
+                Self::Finished => "finished",
+                Self::Title => "title",
+                Self::Priority => "priority",
+                Self::Tag => "tag",
+                Self::NoSort => "",
+            }
+        )
+    }
 }
 
 impl From<&str> for SortMode {
@@ -36,16 +55,30 @@ impl From<&str> for SortMode {
     }
 }
 
-pub enum SortDirection {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortOrder {
     DESC,
     ASC,
 }
 
-impl From<&str> for SortDirection {
+impl fmt::Display for SortOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::DESC => "DESC",
+                _ => "ASC",
+            }
+        )
+    }
+}
+
+impl From<&str> for SortOrder {
     fn from(s: &str) -> Self {
         match s {
-            "desc" => SortDirection::DESC,
-            "asc" => SortDirection::ASC,
+            "desc" => SortOrder::DESC,
+            "asc" => SortOrder::ASC,
             _ => panic!("invalid sort direction"),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,45 @@ pub enum ExportType {
     Tsv,
 }
 
+pub enum SortMode {
+    Id,
+    Due,
+    Finished,
+    Title,
+    Priority,
+    Tag,
+    NoSort,
+}
+
+impl From<&str> for SortMode {
+    fn from(s: &str) -> Self {
+        match s {
+            "id" => SortMode::Id,
+            "due" => SortMode::Due,
+            "finished" => SortMode::Finished,
+            "title" => SortMode::Title,
+            "priority" => SortMode::Priority,
+            "tag" => SortMode::Tag,
+            _ => SortMode::NoSort,
+        }
+    }
+}
+
+pub enum SortDirection {
+    DESC,
+    ASC,
+}
+
+impl From<&str> for SortDirection {
+    fn from(s: &str) -> Self {
+        match s {
+            "desc" => SortDirection::DESC,
+            "asc" => SortDirection::ASC,
+            _ => panic!("invalid sort direction"),
+        }
+    }
+}
+
 impl fmt::Display for ExportType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
- implements #16 
- adds sorting to `opus list`:
```
--sort_by <sort_by>        sort tasks by given param: (id, due, finished, title, priority, tag)
--sort_order <sort_order>  sort direction: (asc, desc)
```

```bash
# sort list output by task property
opus list --sort_by=id
opus list --sort_by=due
opus list --sort_by=finished
opus list --sort_by=title
opus list --sort_by=priority
opus list --sort_by=tag
# sort desc and asc (default sort is asc)
opus list --sort_by=id --sort_mode=desc
# [2]: 'read c how to' (2022-10-17)
# [1]: 'notion aufsetzen' (2022-10-18) #uni .1
# --
# 2 tasks found matching query: 'list'
```