### PR TITLE
fix: get add task content as owned string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,9 +118,9 @@ fn main() {
         }
         Some(("add", sub_matches)) => {
             let t: Task = Task::from(
-                *sub_matches
-                    .get_one::<&str>("CONTENT")
-                    .expect("Failure in parsing task"),
+                &sub_matches
+                    .get_one::<String>("CONTENT")
+                    .expect("Failure in parsing task")[..],
             );
 
             cli_add_task(&db, t);


### PR DESCRIPTION
`get_one` only allows to get values that are `String` or can be converted from it like `usize` etc. It (sadly) doesn't support getting a borrowed string.

Fixes the panic that is caused by requesting a `&str` that look like this:
```
thread 'main' panicked at 'Mismatch between definition and access of `CONTENT`. Could not downcast to &str, need to downcast to alloc::string::String
', src/main.rs:124:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```